### PR TITLE
Update ServiceProvider to expected namespace

### DIFF
--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Thoughtco\StatamicRestrictFields;
+namespace Thoughtco\RestrictFields;
 
 use Statamic\Providers\AddonServiceProvider;
 


### PR DESCRIPTION
The namespace in here is `Thoughtco\StatamicRestrictFields`, but composer expects it to be called only `Thoughtco\RestrictFields` and throws an error when requiring it.  Once changed, the installation seems to work fine!