### PR TITLE
Have fields visible always for Super Admins

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,3 +28,5 @@ Use with a value in the format:
 
 Use with a value in the format:
 `restrictRoles:role_slug_1,role_slug_2`
+
+> Fields will be always visible to Super Admins for all three types of restrictions.

--- a/resources/js/RestrictConditions.js
+++ b/resources/js/RestrictConditions.js
@@ -1,12 +1,12 @@
 
 Statamic.$conditions.add('restrictUsers', function ({ target, params, store, storeName, values }) {
-    return params.includes(Statamic.user.id);
+    return Statamic.user.super || params.includes(Statamic.user.id);
 });
 
 Statamic.$conditions.add('restrictGroups', function ({ target, params, store, storeName, values }) {
-    return params.filter(value => Statamic.user.groups.includes(value)).length > 0;
+    return Statamic.user.super || params.filter(value => Statamic.user.groups.includes(value)).length > 0;
 });
 
 Statamic.$conditions.add('restrictRoles', function ({ target, params, store, storeName, values }) {
-    return params.filter(value => Statamic.user.roles.includes(value)).length > 0;
+    return Statamic.user.super || params.filter(value => Statamic.user.roles.includes(value)).length > 0;
 });


### PR DESCRIPTION
**Idea:** 
I have noticed than when I am logged in as a Super Admin and have no roles assigned then the field is invisible, and I was under the impression that all fields should be always visible to Super Admins. 

**Solution:**
Another if condition in front of roles check and adjustment on README file.