### PR TITLE
Add `super` pseudo role and group

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,3 +28,9 @@ Use with a value in the format:
 
 Use with a value in the format:
 `restrictRoles:role_slug_1,role_slug_2`
+
+### Including superadmins
+
+You may pass `super` to the `restrictGroups` and `restrictRoles` condition methods in order to include superadmins.
+
+Example: `restrictGroups:super,group_slug_1,group_slug_2`

--- a/resources/js/RestrictConditions.js
+++ b/resources/js/RestrictConditions.js
@@ -4,9 +4,15 @@ Statamic.$conditions.add('restrictUsers', function ({ target, params, store, sto
 });
 
 Statamic.$conditions.add('restrictGroups', function ({ target, params, store, storeName, values }) {
-    return params.filter(value => Statamic.user.groups.includes(value)).length > 0;
+    return (
+        (params.includes('super') && Statamic.user.super) ||
+        (params.filter(value => Statamic.user.groups.includes(value)).length > 0)
+    );
 });
 
 Statamic.$conditions.add('restrictRoles', function ({ target, params, store, storeName, values }) {
-    return params.filter(value => Statamic.user.roles.includes(value)).length > 0;
+    return (
+        (params.includes('super') && Statamic.user.super) ||
+        (params.filter(value => Statamic.user.roles.includes(value)).length > 0)
+    );
 });


### PR DESCRIPTION
This PR creates the possibility to add `super` to the `restrictGroups` and `restrictRoles` conditions in order to be able to apply a condition to superadmins.

So you can use `restrictGroups:super,group_slug_1,group_slug_2` or `restrictRoles:super,role_slug_1,role_slug_2` to include superadmins in a rule.

I also updated the readme.