### PR TITLE
Addons are no longer installable from the Control Panel

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ## How to Install
 
-You can search for this addon in the `Tools > Addons` section of the Statamic control panel and click **install**, or run the following command from your project root:
+Run the following command from your project root:
 
 ``` bash
 composer require thoughtco/statamic-restrict-fields


### PR DESCRIPTION
Addons can no longer be installed from the Control Panel. You can only install addons via `composer` now.